### PR TITLE
Add Getter/Setter for MaxEncoders & Rename bgfx_begin/end to match ne…

### DIFF
--- a/SharpBgfx/Bgfx.cs
+++ b/SharpBgfx/Bgfx.cs
@@ -235,6 +235,7 @@ namespace SharpBgfx {
             native.Resolution.MaxFrameLatency = (byte)settings.MaxFrameLatency;
             native.Callbacks = CallbackShim.CreateShim(settings.CallbackHandler ?? new DefaultCallbackHandler());
             native.PlatformData = settings.PlatformData;
+            native.Limits.MaxEncoders = (ushort)(settings.MaxEncoders > 0 ? settings.MaxEncoders : 1);
 
             return NativeMethods.bgfx_init(&native);
         }
@@ -958,7 +959,7 @@ namespace SharpBgfx {
         /// </summary>
         /// <returns>An encoder instance that can be used to submit commands.</returns>
         public static Encoder Begin () {
-            return new Encoder(NativeMethods.bgfx_begin());
+            return new Encoder(NativeMethods.bgfx_encoder_begin());
         }
 
         class DefaultCallbackHandler : ICallbackHandler {

--- a/SharpBgfx/Capabilities.cs
+++ b/SharpBgfx/Capabilities.cs
@@ -1040,6 +1040,11 @@ namespace SharpBgfx {
         public int BackBufferCount { get; set; }
 
         /// <summary>
+        /// The number of thread encoders. Usually number of jobs thread + the main thread.
+        /// </summary>
+        public int MaxEncoders { get; set; }
+
+        /// <summary>
         /// The maximum allowed frame latency, or zero if you don't care.
         /// </summary>
         public int MaxFrameLatency { get; set; }
@@ -1070,6 +1075,7 @@ namespace SharpBgfx {
             Height = (int)native.Resolution.Height;
             ResetFlags = (ResetFlags)native.Resolution.Flags;
             BackBufferCount = native.Resolution.NumBackBuffers;
+            MaxEncoders = (int)native.Limits.MaxEncoders;
             MaxFrameLatency = native.Resolution.MaxFrameLatency;
             PlatformData = native.PlatformData;
         }

--- a/SharpBgfx/Encoder.cs
+++ b/SharpBgfx/Encoder.cs
@@ -444,7 +444,7 @@ namespace SharpBgfx {
         /// Finishes submission of commands from this encoder.
         /// </summary>
         public void Dispose () {
-            NativeMethods.bgfx_end(ptr);
+            NativeMethods.bgfx_encoder_end(ptr);
         }
 
         /// <summary>

--- a/SharpBgfx/NativeMethods.cs
+++ b/SharpBgfx/NativeMethods.cs
@@ -429,10 +429,10 @@ namespace SharpBgfx {
         public static extern int bgfx_vsnprintf(sbyte* str, IntPtr count, [MarshalAs(UnmanagedType.LPStr)] string format, IntPtr argList);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr bgfx_begin ();
+        public static extern IntPtr bgfx_encoder_begin ();
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void bgfx_end (IntPtr encoder);
+        public static extern void bgfx_encoder_end (IntPtr encoder);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         public static extern void bgfx_encoder_set_marker (IntPtr encoder, [MarshalAs(UnmanagedType.LPStr)] string marker);


### PR DESCRIPTION
…wer BGFX versions

Added a getter/setter for the MaxEncoders value, which is required if you want to do threaded rendering.

Newer versions of BGFX renamed bgfx_begin/end to bgfx_encoder_begin/end. I'm on a custom build of BGFX so this is causing a conflict for me, so I figure I would push this change to you (which would also require an update to the one hosted here)