### PR TITLE
Repair StencilFlags.Equals

### DIFF
--- a/SharpBgfx/StencilFlags.cs
+++ b/SharpBgfx/StencilFlags.cs
@@ -235,7 +235,7 @@ namespace SharpBgfx {
             if (state == null)
                 return false;
 
-            return Equals(state);
+            return Equals(state.Value);
         }
 
         /// <summary>


### PR DESCRIPTION
`return Equals(state);` whitch `state` is `Nullable<StencilFlags>`, will cause infinite recursion.